### PR TITLE
delete peaceiris/actions-gh-pages from deploy_gh_pages.yml

### DIFF
--- a/.github/workflows/deploy_gh_pages.yml
+++ b/.github/workflows/deploy_gh_pages.yml
@@ -8,11 +8,10 @@ on:
 env:
   NODE_VERSION: '20'
 
-permissions:
-  contents: write
-
 jobs:
-  deploy:
+  build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
@@ -25,9 +24,21 @@ jobs:
       - name: Install and Build
         run: |
           npm ci
-      - uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
-          user_name: 'github-actions'
-          user_email: '41898282+github-actions[bot]@users.noreply.github.com'
+          path: ./dist
+
+  deploy:
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
### やったこと
GithubPagesのデプロイワークフローでサードパーティーアクションの`peaceiris/actions-gh-pages`を利用せずに、デプロイ処理ができるように

### その他
- この修正は[Github公式マニュアル](https://docs.github.com/ja/pages/getting-started-with-github-pages/using-custom-workflows-with-github-pages)で公開されているGithubPagesサイト構築方法を参考にしています
- この変更でGithubPagesへの成果物はgh-pagesにpushされなくなります

### このPRのマージ後に必要な対応
- GithubリポジトリのGithubPageの設定で、デプロイ方法を「Deploy from a branch」から「Github Actions」に変更する